### PR TITLE
ci: add support for armhf and arm64 on Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /_out
 /cert-manager-webhook-ovh
 /testdata
+/.github

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -49,6 +56,10 @@ jobs:
         with:
           context: .
           push: true
+          platforms:
+            - linux/arm64
+            - linux/arm/v7
+            - linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
This PR addresses the issue #13 