### PR TITLE
Choose the type of role

### DIFF
--- a/charts/cert-manager-webhook-ovh/templates/rbac.yaml
+++ b/charts/cert-manager-webhook-ovh/templates/rbac.yaml
@@ -125,7 +125,7 @@ subjects:
   {{- end }}{{/* end range */}}
   {{- if len $secretsList }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ $.Values.roleType }}
 metadata:
   name: {{ include "cert-manager-webhook-ovh.fullname" $ }}:secret-reader
   namespace: {{ $.Release.Namespace | quote }}

--- a/charts/cert-manager-webhook-ovh/values.yaml
+++ b/charts/cert-manager-webhook-ovh/values.yaml
@@ -8,6 +8,8 @@
 # here is recommended.
 groupName: acme.mycompany.example
 
+roleType: Role
+
 certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager


### PR DESCRIPTION
If the secret is in another namespace, the webhook cannot read it.

This pull request gives the possibility to choose the type of the role (Role or ClusterRole)