### PR TITLE
Chart security context

### DIFF
--- a/charts/cert-manager-webhook-ovh/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-ovh/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
 {{- if .Values.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
 {{- end }}
       volumes:
         - name: certs

--- a/charts/cert-manager-webhook-ovh/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-ovh/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cert-manager-webhook-ovh.labels" $ | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/charts/cert-manager-webhook-ovh/values.yaml
+++ b/charts/cert-manager-webhook-ovh/values.yaml
@@ -135,13 +135,14 @@ issuers:
     #     # The key name in the secret above that holds the actual OVH consumer key value
     #     key: consumerKey
 
-# If enabled (default) the webhook will run as the specifieduser and group.
-# Furthermore, the specified allowPrivilegeEscalation is applied to the pod.
+# If enabled (default) the webhook will run as the specified user and group.
+# Furthermore, the specified allowPrivilegeEscalation and readOnlyRootFilesystem is applied to the container.
 securityContext:
   enabled: true
   runAsUser: 1000
   runAsGroup: 1000
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 image:
   repository: ghcr.io/aureq/cert-manager-webhook-ovh

--- a/charts/cert-manager-webhook-ovh/values.yaml
+++ b/charts/cert-manager-webhook-ovh/values.yaml
@@ -188,3 +188,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+annotations: {}


### PR DESCRIPTION
This adds support for setting `readOnlyRootFilesystem` on the container and to add `annotations` to the deployment, helps with [kubeaudit](https://github.com/Shopify/kubeaudit/tree/main) checks.