### PR TITLE
fix(chart): Fix app.kubernetes.io/version label when using SHA in image tag

### DIFF
--- a/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
@@ -102,7 +102,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: cert-manager
 {{ include "cert-manager-webhook-ovh.selectorLabels" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ (.Values.image.tag | default .Chart.AppVersion | split "@")._0 | quote }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Fix issue #41 by keeping only image tag without SHA.

Test commands:
- `helm template test charts/cert-manager-webhook-ovh --set configVersion=0.0.1 --set image.tag='0.6.0@sha256:6e38b4420232ec6ab6ed2e75d15b7b5b60088a886ac28ef30cc4327fd3ad1c9c' | grep 'app.kubernetes.io/version' | uniq` => Returns  `app.kubernetes.io/version: "0.6.0"`
- `helm template test charts/cert-manager-webhook-ovh --set configVersion=0.0.1 --set image.tag='0.6.0' | grep 'app.kubernetes.io/version' | uniq` => Returns  `app.kubernetes.io/version: "0.6.0"`
- `helm template test charts/cert-manager-webhook-ovh --set configVersion=0.0.1 | grep 'app.kubernetes.io/version' | uniq` => Returns  `app.kubernetes.io/version: "0.7.5"` (chart appVersion)