### PR TITLE
Fix TXT record not deleted because of quotes implictly added in target field returned by OVH API

### DIFF
--- a/main.go
+++ b/main.go
@@ -304,7 +304,8 @@ func removeTXTRecord(ovhClient *ovh.Client, domain, subDomain, target string) er
 		if err != nil {
 			return err
 		}
-		if record.Target != target {
+		// Remove surrounded quotes as OVH seems to implicitly add them for a TXT record
+		if strings.Trim(record.Target, "\"") != target {
 			continue
 		}
 		err = deleteRecord(ovhClient, domain, id)


### PR DESCRIPTION
The issue described in #66 occurs because TXT recorded are not deleted anymore. This is because OVH API now returns TXT entry content surrounded by quotes.