### PR TITLE
Fix ACME challenge subdomain parsing for multi-level subdomains

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,11 +309,22 @@ func loadConfig(cfgJSON *extapi.JSON) (ovhDNSProviderConfig, error) {
 // by removing the main domain part. If the main domain is not found in the FQDN,
 // it returns the FQDN without the trailing dot.
 func getSubDomain(domain, fqdn string) string {
-	if idx := strings.Index(fqdn, "."+domain); idx != -1 {
-		return fqdn[:idx]
+	// Ensure both domain and fqdn are in unfqdn format for comparison
+	domain = util.UnFqdn(domain)
+	fqdn = util.UnFqdn(fqdn)
+
+	// Check if fqdn ends with the domain
+	if strings.HasSuffix(fqdn, "."+domain) {
+		// Remove the domain part and the dot before it
+		return strings.TrimSuffix(fqdn, "."+domain)
 	}
 
-	return util.UnFqdn(fqdn)
+	// If the fqdn equals the domain exactly, return empty string
+	if fqdn == domain {
+		return ""
+	}
+
+	return fqdn
 }
 
 // addTXTRecord adds a TXT record to the OVH DNS zone for the specified domain and subdomain.


### PR DESCRIPTION
### Problem
When creating ACME challenge TXT records for multi-level subdomains, the webhook was incorrectly truncating intermediate subdomain levels.

**Example:**
- For domain: `name.develop.name.dev`
- Expected TXT record: `_acme-challenge.name.develop.name.dev`
- Actual TXT record created: `_acme-challenge.name.dev` ❌

This caused certificate validation to fail because the ACME challenge record was created at the wrong DNS level.

### Root Cause
The `getSubDomain()` function used `strings.Index()` to find the first occurrence of the base domain in the FQDN. For multi-level subdomains, this incorrectly matched intermediate occurrences of the domain name, truncating everything after the first match.

### Solution
Replaced `strings.Index()` with `strings.HasSuffix()` and `strings.TrimSuffix()` to correctly remove only the base domain suffix from the end of the FQDN, preserving all intermediate subdomain levels.

**After fix:**
- For domain: `name.develop.name.dev`
- TXT record now correctly created at: `_acme-challenge.name.develop.name.dev` ✅

### Changes
- Updated `getSubDomain()` function in `main.go` to use suffix-based matching instead of index-based matching
- Added proper handling for edge cases (FQDN equals domain exactly)