### PR TITLE
Fix handling of externalAccountBinding in the chart

### DIFF
--- a/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
@@ -103,7 +103,7 @@ Return the proper image name
 Returns true if externalAccountBinding is correctly set.
 */}}
 {{- define "cert-manager-webhook-ovh.isExternalAccountBindingAvail" -}}
-  {{- if .externalAccountBinding.enabled -}}
+  {{- if (.externalAccountBinding).enabled -}}
     {{- if and (.externalAccountBinding.keyID) (.externalAccountBinding.keySecretRef.name) (.externalAccountBinding.keySecretRef.key) -}}
       {{- eq "true" "true" -}}
     {{- end -}}

--- a/charts/cert-manager-webhook-ovh/values.schema.json
+++ b/charts/cert-manager-webhook-ovh/values.schema.json
@@ -181,9 +181,20 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "keyID",
-                  "keySecretRef"
+                "anyOf": [
+                  {
+                    "not": {
+                      "properties": {
+                        "enabled": { "enum": [true] }
+                      },
+                      "required": []
+                    }
+                  },
+                  { "required": [
+                      "keyID",
+                      "keySecretRef"
+                    ]
+                  }
                 ],
                 "title": "externalAccountBinding",
                 "type": "object"


### PR DESCRIPTION
Addresses the error mentioned in [#79](https://github.com/aureq/cert-manager-webhook-ovh/issues/79#issuecomment-3939375221).

Also values inside of `externalAccountBinding` are now only required if `enabled` is true.