### PR TITLE
fix: trim and replace illegal ':' when tag is a digest

### DIFF
--- a/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-ovh/templates/_helpers.tpl
@@ -73,7 +73,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: cert-manager
 {{ include "cert-manager-webhook-ovh.selectorLabels" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
-app.kubernetes.io/version: {{ (.Values.image.tag | default .Chart.AppVersion | split "@")._0 | quote }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString }}
+{{- $tag := hasPrefix "sha256:" $tag | ternary ($tag | trimPrefix "sha256:" | trunc 32) $tag }}
+app.kubernetes.io/version: {{ ($tag | split "@")._0 | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/cert-manager-webhook-ovh/templates/validator.yaml
+++ b/charts/cert-manager-webhook-ovh/templates/validator.yaml
@@ -103,3 +103,22 @@ the template will `fail` with a clear error message indicating the reason of the
 {{- if eq ($.Values.groupName | trim) "" -}}
   {{- fail "Invalid configuration: Missing value for required field 'groupName'." -}}
 {{- end -}}
+
+{{- /*
+  📄 validate any labels returned by the `cert-manager-webhook-ovh.labels` template.
+
+  The code below checks that all labels returned by `cert-manager-webhook-ovh` do not include any
+  illegal charaters, and are at most 63 characters long. If the validation fails, the template will
+  `fail` with a clear error message indicating the reason of the failure.
+*/ -}}
+
+{{- $labels := include "cert-manager-webhook-ovh.labels" . | fromYaml -}}
+{{- range $key, $value := $labels -}}
+  {{- $value = $value | toString -}}
+  {{- if not (regexMatch "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" $value)  -}}
+    {{- fail (printf "Invalid label value for '%s': '%s' contains invalid characters." $key $value) -}}
+  {{- end -}}
+  {{- if gt (len $value) 63  -}}
+    {{- fail (printf "Invalid label value for '%s': '%s' is over the 63 character limit." $key $value) -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/cert-manager-webhook-ovh/tests/labels_test.yaml
+++ b/charts/cert-manager-webhook-ovh/tests/labels_test.yaml
@@ -1,0 +1,23 @@
+---
+suite: Testing `image.tag` option set to a digest in all templates
+templates:
+  - '*.yaml'
+values:
+  - values/valid/values-tag-digest-gets-truncated.yaml
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+tests:
+  - it: Validate succesful rendering with a digest in `image.tag`
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: Validate digest truncation in `app.kubernetes.io/version` label
+    documentSelector:
+      path: metadata.labels
+      matchMany: true
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: abcdef0123456789abcdef0123456789

--- a/charts/cert-manager-webhook-ovh/tests/validator_test.yaml
+++ b/charts/cert-manager-webhook-ovh/tests/validator_test.yaml
@@ -155,3 +155,31 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Invalid configuration: Missing value for required field 'groupName'."
+---
+suite: Testing `validator.yaml` 12/x
+templates:
+  - validator.yaml
+values:
+  - values/invalid/values-label-invalid-chars.yaml
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+tests:
+  - it: Validate failed rendering in `validator.yaml` 1/x
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid label value for 'app.kubernetes.io/name': 'this-name-contains-invalid-chars?' contains invalid characters."
+---
+suite: Testing `validator.yaml` 13/x
+templates:
+  - validator.yaml
+values:
+  - values/invalid/values-label-longer-than-limit.yaml
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+tests:
+  - it: Validate failed rendering in `validator.yaml` 1/x
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid label value for 'app.kubernetes.io/version': 'this.is.a.very.long.image.tag.abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789' is over the 63 character limit."

--- a/charts/cert-manager-webhook-ovh/tests/values/invalid/values-label-invalid-chars.yaml
+++ b/charts/cert-manager-webhook-ovh/tests/values/invalid/values-label-invalid-chars.yaml
@@ -1,0 +1,432 @@
+# vim: set ft=yaml
+# yaml-language-server: $schema=../../../values.schema.json
+
+groupName: acme.helm.unittest.example
+
+certManager:
+  namespace: cert-system
+  serviceAccountName: cert-manager
+
+issuers:
+
+  - name: letsencrypt-prod
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: cert-system
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: true
+    profile: classic
+    preferredChain: 'ISRG Root X1'
+    cnameStrategy: Follow
+    externalAccountBinding:
+      enabled: true
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: 'oclientid-0123456789abcdef'
+      oauth2ClientSecret: 'oclientsecret-0123456789abcdef'
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: not-letsencrypt-prod
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: not-le-staging-app-ref
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: letsencrypt-prod-no-profile
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    # profile: classic
+    preferredChain: ''
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+rbac:
+  roleType: Role
+
+image:
+  registry: 'ghcr.io'
+  repository: aureq/cert-manager-webhook-ovh
+  tag: ''
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+pod:
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  replicas: 1
+  environment:
+    HTTP_PROXY: "http://proxy.example.net:3129"
+    HTTPS_PROXY: "http://proxy.example.net:3129"
+    NO_PROXY: "10.0.0.0/8,127.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.svc,*.cluster.local,*.svc.cluster.local,169.254.169.254,127.0.0.1,localhost,localhost.localdomain"
+
+  securityContext:
+    pod:
+      runAsUser: 1000
+      runAsGroup: 1000
+    container:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      privileged: false
+
+  port: 8443
+  hostNetwork: false
+  priorityClassName: ''
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 96Mi
+
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+    tolerationSeconds: 3600
+
+  selectors:
+    nodeSelector:
+      disktype: ssd
+      kubernetes.io/os: linux
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: 'kubernetes.io/hostname'
+              operator: 'In'
+              values:
+              - 'worker-1'
+              - 'worker-2'
+
+nameOverride: "this-name-contains-invalid-chars?"
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+  annotations: {}
+
+extraObjects: []

--- a/charts/cert-manager-webhook-ovh/tests/values/invalid/values-label-longer-than-limit.yaml
+++ b/charts/cert-manager-webhook-ovh/tests/values/invalid/values-label-longer-than-limit.yaml
@@ -1,0 +1,432 @@
+# vim: set ft=yaml
+# yaml-language-server: $schema=../../../values.schema.json
+
+groupName: acme.helm.unittest.example
+
+certManager:
+  namespace: cert-system
+  serviceAccountName: cert-manager
+
+issuers:
+
+  - name: letsencrypt-prod
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: cert-system
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: true
+    profile: classic
+    preferredChain: 'ISRG Root X1'
+    cnameStrategy: Follow
+    externalAccountBinding:
+      enabled: true
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: 'oclientid-0123456789abcdef'
+      oauth2ClientSecret: 'oclientsecret-0123456789abcdef'
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: not-letsencrypt-prod
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: not-le-staging-app-ref
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: letsencrypt-prod-no-profile
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    # profile: classic
+    preferredChain: ''
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+rbac:
+  roleType: Role
+
+image:
+  registry: 'ghcr.io'
+  repository: aureq/cert-manager-webhook-ovh
+  tag: 'this.is.a.very.long.image.tag.abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+pod:
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  replicas: 1
+  environment:
+    HTTP_PROXY: "http://proxy.example.net:3129"
+    HTTPS_PROXY: "http://proxy.example.net:3129"
+    NO_PROXY: "10.0.0.0/8,127.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.svc,*.cluster.local,*.svc.cluster.local,169.254.169.254,127.0.0.1,localhost,localhost.localdomain"
+
+  securityContext:
+    pod:
+      runAsUser: 1000
+      runAsGroup: 1000
+    container:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      privileged: false
+
+  port: 8443
+  hostNetwork: false
+  priorityClassName: ''
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 96Mi
+
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+    tolerationSeconds: 3600
+
+  selectors:
+    nodeSelector:
+      disktype: ssd
+      kubernetes.io/os: linux
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: 'kubernetes.io/hostname'
+              operator: 'In'
+              values:
+              - 'worker-1'
+              - 'worker-2'
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+  annotations: {}
+
+extraObjects: []

--- a/charts/cert-manager-webhook-ovh/tests/values/valid/values-tag-digest-gets-truncated.yaml
+++ b/charts/cert-manager-webhook-ovh/tests/values/valid/values-tag-digest-gets-truncated.yaml
@@ -1,0 +1,432 @@
+# vim: set ft=yaml
+# yaml-language-server: $schema=../../../values.schema.json
+
+groupName: acme.helm.unittest.example
+
+certManager:
+  namespace: cert-system
+  serviceAccountName: cert-manager
+
+issuers:
+
+  - name: letsencrypt-prod
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: cert-system
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: true
+    profile: classic
+    preferredChain: 'ISRG Root X1'
+    cnameStrategy: Follow
+    externalAccountBinding:
+      enabled: true
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: 'oclientid-0123456789abcdef'
+      oauth2ClientSecret: 'oclientsecret-0123456789abcdef'
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-oidc-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: oauth2
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: 'ovh-credentials'
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-dir
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: le-staging-app-ref
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: not-letsencrypt-prod
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+  - name: not-le-staging-app-ref
+    create: false
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    profile: classic
+    cnameStrategy: None
+    externalAccountBinding:
+      enabled: false
+      keyID: my-keyid-1
+      keySecretRef:
+        name: eab-key-secret
+        key: eabKey
+    ovhEndpointName: ovh-eu
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: ''
+      applicationSecret: ''
+      applicationConsumerKey: ''
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: 'ovh-credentials'
+        key: applicationKey
+      applicationSecretRef:
+        name: 'ovh-credentials'
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: 'ovh-credentials'
+        key: applicationConsumerKey
+
+  - name: letsencrypt-prod-no-profile
+    create: true
+    kind: ClusterIssuer
+    namespace: default
+    acmeServerUrl: https://acme-v02.api.letsencrypt.org/directory
+    email: tls-manager@example.net
+    disableAccountKeyGeneration: false
+    # profile: classic
+    preferredChain: ''
+    cnameStrategy: None
+
+    externalAccountBinding:
+      enabled: false
+      keyID: ''
+
+      keySecretRef:
+        name: ''
+        key: ''
+
+    ovhEndpointName: ovh-eu
+
+    ovhAuthenticationMethod: application
+
+    ovhAuthentication:
+      oauth2ClientID: ''
+      oauth2ClientSecret: ''
+      applicationKey: 'appkey-0123456789abcdef'
+      applicationSecret: 'appsecret-0123456789abcdef'
+      applicationConsumerKey: 'appconsumerkey-0123456789abcdef'
+
+    ovhAuthenticationRef:
+      oauth2ClientIDRef:
+        name: ''
+        key: oauth2ClientID
+      oauth2ClientSecretRef:
+        name: ''
+        key: oauth2ClientSecret
+      applicationKeyRef:
+        name: ''
+        key: applicationKey
+      applicationSecretRef:
+        name: ''
+        key: applicationSecret
+      applicationConsumerKeyRef:
+        name: ''
+        key: applicationConsumerKey
+
+rbac:
+  roleType: Role
+
+image:
+  registry: 'ghcr.io'
+  repository: aureq/cert-manager-webhook-ovh
+  tag: 'sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+pod:
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  replicas: 1
+  environment:
+    HTTP_PROXY: "http://proxy.example.net:3129"
+    HTTPS_PROXY: "http://proxy.example.net:3129"
+    NO_PROXY: "10.0.0.0/8,127.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.svc,*.cluster.local,*.svc.cluster.local,169.254.169.254,127.0.0.1,localhost,localhost.localdomain"
+
+  securityContext:
+    pod:
+      runAsUser: 1000
+      runAsGroup: 1000
+    container:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      privileged: false
+
+  port: 8443
+  hostNetwork: false
+  priorityClassName: ''
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 96Mi
+
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+    tolerationSeconds: 3600
+
+  selectors:
+    nodeSelector:
+      disktype: ssd
+      kubernetes.io/os: linux
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: 'kubernetes.io/hostname'
+              operator: 'In'
+              values:
+              - 'worker-1'
+              - 'worker-2'
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+  annotations: {}
+
+extraObjects: []


### PR DESCRIPTION
## Description

<!-- Please describe your change. -->

While applying the chart with a digest as `image.tag`, I ran into the following validation error:

> `unable to generate manifests: cannot patch "cert-manager-webhook-ovh" with kind ServiceAccount: ServiceAccount "cert-manager-webhook-ovh" is invalid: [metadata.labels: Invalid value: "sha256:0339cf9a75ca217168a4753f8d3de8ed09ba29151c95e052f0cabfeb3439c82a": must be no more than 63 bytes, metadata.labels: Invalid value: "sha256:0339cf9a75ca217168a4753f8d3de8ed09ba29151c95e052f0cabfeb3439c82a": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]`

After checking Kubernetes' label documentation (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set), I verified that using the raw digest as a label value was over the maximum length and contained an illegal `:`.

This change removes the `sha256:` prefix from the digest, and trims the hash to just the first 32 chars.
I initially opted to trim the digest to 63 chars, but it felt like an odd length for a sha256 checksum so I changed it to 32 instead. I have no strong opinion, so I can update the PR to do it that way if you prefer.

note: a newline terminator seemed to be missing from the file I edited, which is why it seems to show up in the diff.

## Related Issue

<!-- Please link to the issue here. -->

PR #63 solved this issue when using `$tag:$digest` as `image.tag`. However, it would still occur if the digest is used directly (which is supported, per the [schema](https://github.com/aureq/cert-manager-webhook-ovh/blob/main/charts/cert-manager-webhook-ovh/values.yaml#L422)).

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Other (please describe)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] The [Code of Conduct](https://github.com/aureq/cert-manager-webhook-ovh/blob/main/CODE_OF_CONDUCT.md) has been read and is agreed to by the PR author.
- [ ] `Chart.yaml` `version` has been bumped for every chart you modified.
- [ ] `charts/cert-manager-webhook-ovh/README.md` was **not** edited directly; `charts/cert-manager-webhook-ovh/README.md.gotmpl` and/or `values.yaml` were edited instead.
- [ ] `values.schema.json` was **not** edited directly; `values.yaml` `# @schema` annotations were edited instead.
- [ ] `make helm-docs helm-schema` has been run, the regenerated files are committed and the changes are part of this PR.
- [ ] Relevant to the changes, unit tests have been added, and existing tests have been updated as needed.
- [x] `make tests` passes locally.
- [ ] `CHANGELOG.md` has been updated with a description of the change and a link to this PR.
- [x] Commit messages and PR title are descriptive, concise and follow this project's conventions.
- [x] All usage of Generative AI is fully disclosed in the PR description in complete compliance with the
  [Generative AI Guidelines](https://github.com/aureq/cert-manager-webhook-ovh/blob/main/CODE_OF_CONDUCT.md#generative-ai).
